### PR TITLE
Add LRU

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -117,7 +117,7 @@ type LRU struct {
 	// mem is in-memory lru cache layer
 	mem *lru.TwoQueueCache[string, *proto.AccessQuota]
 
-	// backend is pluggable cache layer, which usually is redis
+	// backend is pluggable QuotaCache layer, which usually is redis
 	backend QuotaCache
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,1 +1,46 @@
 package quotacontrol_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/0xsequence/quotacontrol"
+	"github.com/0xsequence/quotacontrol/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCache struct {
+	count int32
+}
+
+func (s *mockCache) GetAccessQuota(ctx context.Context, accessKey string) (*proto.AccessQuota, error) {
+	atomic.AddInt32(&s.count, 1)
+	return &proto.AccessQuota{AccessKey: &proto.AccessKey{AccessKey: accessKey}}, nil
+}
+
+func (s *mockCache) SetAccessQuota(ctx context.Context, accessKey *proto.AccessQuota) error {
+	return nil
+}
+
+func (s *mockCache) DeleteAccessKey(ctx context.Context, accessKey string) error {
+	return nil
+}
+
+func TestLRU(t *testing.T) {
+	baseCache := mockCache{}
+
+	lru, err := quotacontrol.NewLRU(&baseCache, 2)
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = lru.GetAccessQuota(ctx, "a")
+	assert.NoError(t, err)
+
+	_, err = lru.GetAccessQuota(ctx, "a")
+	assert.NoError(t, err)
+
+	assert.Equal(t, int32(1), baseCache.count)
+
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -42,5 +42,4 @@ func TestLRU(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, int32(1), baseCache.count)
-
 }

--- a/client.go
+++ b/client.go
@@ -71,7 +71,7 @@ type Client struct {
 
 var _ middleware.Client = &Client{}
 
-// FetchAccessQuota fetches and validates the accessKey from cache or from the quota server.
+// FetchQuota fetches and validates the accessKey from cache or from the quota server.
 func (c *Client) FetchQuota(ctx context.Context, accessKey, origin string) (*proto.AccessQuota, error) {
 	// fetch access quota
 	quota, err := c.quotaCache.GetAccessQuota(ctx, accessKey)

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	UpdateFreq  Duration          `toml:"update_freq"`
 	RateLimiter RateLimiterConfig `toml:"rate_limiter"`
 	Redis       redis.Config      `toml:"redis"`
+	LRUSize     int               `toml:"lru_size"`
 }
 
 type RateLimiterConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-chi/httprate-redis v0.2.1
 	github.com/go-redis/redis_rate/v10 v10.0.1
 	github.com/goware/cachestore v0.8.1
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jxskiss/base62 v1.1.0
 	github.com/redis/go-redis/v9 v9.2.1
 	github.com/rs/zerolog v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -26,7 +26,8 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/goware/cachestore v0.8.1 h1:UjSjFiB27vjGq4JK8aBMqsAI4sa7cbrHToFDsM0cjHw=
 github.com/goware/cachestore v0.8.1/go.mod h1:ikiO2RmxIt4cVqEBII6yR+V4Z7pH+y8bMQHpd1MvG1Y=
 github.com/goware/singleflight v0.2.0 h1:e/hZsvNmbLoiZLx3XbihH01oXYA2MwLFo4e+N017U4c=
-github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jxskiss/base62 v1.1.0 h1:A5zbF8v8WXx2xixnAKD2w+abC+sIzYJX+nxmhA6HWFw=
 github.com/jxskiss/base62 v1.1.0/go.mod h1:HhWAlUXvxKThfOlZbcuFzsqwtF5TcqS9ru3y5GfjWAc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/middleware/access.go
+++ b/middleware/access.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	HeaderAccessKey = "X-Access-Key"
-	HeaderOrigin    = "Origin"
+	HeaderAccessKey       = "X-Access-Key"
+	HeaderAccessKeyLegacy = "X-Sequence-Token-Key"
+	HeaderOrigin          = "Origin"
 )
 
 // Client is the interface that wraps the basic FetchQuota, GetUsage and SpendQuota methods.
@@ -27,6 +28,10 @@ type ErrorHandler func(w http.ResponseWriter, r *http.Request, next http.Handler
 func SetAccessKey(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accessKey := r.Header.Get(HeaderAccessKey)
+		if accessKey == "" {
+			// TODO: remove legacy header support
+			accessKey = r.Header.Get(HeaderAccessKeyLegacy)
+		}
 		ctx := r.Context()
 		if accessKey != "" {
 			ctx = WithAccessKey(ctx, accessKey)

--- a/quotacontrol_test.go
+++ b/quotacontrol_test.go
@@ -34,6 +34,7 @@ var (
 			Enabled:                 true,
 			PublicRequestsPerMinute: 10,
 		},
+		LRUSize: 100,
 	}
 )
 
@@ -58,7 +59,7 @@ func TestMiddlewareUseAccessKey(t *testing.T) {
 	store.InsertAccessKey(ctx, &access)
 	client := NewClient(zerolog.Nop(), proto.Service_Indexer, cfg)
 	qc := quotaControl{
-		QuotaControl:  NewQuotaControl(cache, store, store, store),
+		QuotaControl:  NewQuotaControl(cache, cache, store, store, store),
 		notifications: make(map[uint64][]proto.EventType),
 	}
 	server := http.Server{


### PR DESCRIPTION
This PR splits the `Cache` interface into `QuotaCache` and `UsageCache`.
The existing `RedisCache` already implements both of them.

There is a new type `LRU` which can wrap a `QuotaCache` to add an in-memory LRU cache.