### PR TITLE
match subdomain with wildcard and http scheme defined

### DIFF
--- a/proto/proto.go
+++ b/proto/proto.go
@@ -28,10 +28,24 @@ func matchDomain(domain, pattern string) bool {
 	if pattern == "*" {
 		return true
 	}
-	if strings.HasPrefix(pattern, "*.") {
-		return strings.HasSuffix(domain, pattern[1:])
+
+	// switch to http scheme by default
+	if !strings.HasPrefix(pattern, "http") {
+		pattern = fmt.Sprintf("http://%s", pattern)
 	}
-	return domain == pattern
+
+	u, err := url.Parse(pattern)
+	if err != nil {
+		return false
+	}
+
+	// match pattern with wildcard
+	if strings.Contains(pattern, "*.") {
+		schemePrefix := fmt.Sprintf("%s://", u.Scheme)
+		return strings.HasPrefix(domain, u.Scheme) && strings.HasSuffix(domain[len(schemePrefix):], pattern[strings.Index(pattern, "*")+1:])
+	}
+
+	return domain == u.String()
 }
 
 func (t *AccessKey) ValidateOrigin(rawOrigin string) bool {
@@ -43,7 +57,7 @@ func (t *AccessKey) ValidateOrigin(rawOrigin string) bool {
 		return false
 	}
 	for _, o := range t.AllowedOrigins {
-		if matchDomain(origin.Host, o) {
+		if matchDomain(origin.String(), o) {
 			return true
 		}
 	}

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -28,11 +28,8 @@ func matchDomain(domain, pattern string) bool {
 		return true
 	}
 
-	i := strings.Index(pattern, "*")
-	if i != -1 {
-		prefix := pattern[0:i]
-		suffix := pattern[i+1:]
-
+	prefix, suffix, found := strings.Cut(pattern, "*")
+	if found {
 		return len(domain) >= len(prefix+suffix) && strings.HasPrefix(domain, prefix) && strings.HasSuffix(domain, suffix)
 	}
 

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -2,7 +2,6 @@ package proto
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 )
@@ -29,35 +28,25 @@ func matchDomain(domain, pattern string) bool {
 		return true
 	}
 
-	// switch to http scheme by default
-	if !strings.HasPrefix(pattern, "http") {
-		pattern = fmt.Sprintf("http://%s", pattern)
+	i := strings.Index(pattern, "*")
+	if i != -1 {
+		prefix := pattern[0:i]
+		suffix := pattern[i+1:]
+
+		return len(domain) >= len(prefix+suffix) && strings.HasPrefix(domain, prefix) && strings.HasSuffix(domain, suffix)
 	}
 
-	u, err := url.Parse(pattern)
-	if err != nil {
-		return false
-	}
-
-	// match pattern with wildcard
-	if strings.Contains(pattern, "*.") {
-		schemePrefix := fmt.Sprintf("%s://", u.Scheme)
-		return strings.HasPrefix(domain, u.Scheme) && strings.HasSuffix(domain[len(schemePrefix):], pattern[strings.Index(pattern, "*")+1:])
-	}
-
-	return domain == u.String()
+	return domain == pattern
 }
 
 func (t *AccessKey) ValidateOrigin(rawOrigin string) bool {
 	if len(t.AllowedOrigins) == 0 {
 		return true
 	}
-	origin, err := url.Parse(rawOrigin)
-	if err != nil {
-		return false
-	}
+
+	origin := strings.ToLower(rawOrigin)
 	for _, o := range t.AllowedOrigins {
-		if matchDomain(origin.String(), o) {
+		if matchDomain(origin, o) {
 			return true
 		}
 	}

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -28,12 +28,21 @@ func matchDomain(domain, pattern string) bool {
 		return true
 	}
 
-	prefix, suffix, found := strings.Cut(pattern, "*")
-	if found {
-		return len(domain) >= len(prefix+suffix) && strings.HasPrefix(domain, prefix) && strings.HasSuffix(domain, suffix)
+	prefix, suffix, hasWildcard := strings.Cut(pattern, "*")
+	if !hasWildcard {
+		return domain == pattern
 	}
 
-	return domain == pattern
+	if len(domain) < len(prefix+suffix) {
+		return false
+	}
+	if !strings.HasPrefix(domain, prefix) {
+		return false
+	}
+	if !strings.HasSuffix(domain, suffix) {
+		return false
+	}
+	return true
 }
 
 func (t *AccessKey) ValidateOrigin(rawOrigin string) bool {

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -15,18 +15,25 @@ func TestAccessKeyValidateOrigin(t *testing.T) {
 
 	t.Run("allowed origins", func(t *testing.T) {
 		tk := &proto.AccessKey{
-			AllowedOrigins: []string{"localhost:8080", "localhost:8081"},
+			AllowedOrigins: []string{"http://localhost:8080", "http://localhost:8081"},
 		}
 		assert.True(t, tk.ValidateOrigin("http://localhost:8080"))
 		assert.True(t, tk.ValidateOrigin("http://localhost:8081"))
 		assert.False(t, tk.ValidateOrigin("http://localhost:8082"))
 	})
 
+	t.Run("match any", func(t *testing.T) {
+		tk := &proto.AccessKey{
+			AllowedOrigins: []string{"*"},
+		}
+		assert.True(t, tk.ValidateOrigin("http://sequence.xyz"))
+		assert.True(t, tk.ValidateOrigin("https://localhost:8080"))
+	})
+
 	t.Run("match http scheme", func(t *testing.T) {
 		tk := &proto.AccessKey{
 			AllowedOrigins: []string{"https://localhost:8080", "https://*.sequence.xyz"},
 		}
-
 		assert.True(t, tk.ValidateOrigin("https://local.sequence.xyz"))
 		assert.True(t, tk.ValidateOrigin("https://localhost:8080"))
 		assert.False(t, tk.ValidateOrigin("http://localhost:8080"))

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -21,6 +21,17 @@ func TestAccessKeyValidateOrigin(t *testing.T) {
 		assert.True(t, tk.ValidateOrigin("http://localhost:8081"))
 		assert.False(t, tk.ValidateOrigin("http://localhost:8082"))
 	})
+
+	t.Run("match http scheme", func(t *testing.T) {
+		tk := &proto.AccessKey{
+			AllowedOrigins: []string{"https://localhost:8080", "https://*.sequence.xyz"},
+		}
+
+		assert.True(t, tk.ValidateOrigin("https://local.sequence.xyz"))
+		assert.True(t, tk.ValidateOrigin("https://localhost:8080"))
+		assert.False(t, tk.ValidateOrigin("http://localhost:8080"))
+	})
+
 	t.Run("wildcards", func(t *testing.T) {
 		tk := &proto.AccessKey{
 			AllowedOrigins: []string{"*.sequence.xyz"},
@@ -28,6 +39,7 @@ func TestAccessKeyValidateOrigin(t *testing.T) {
 		assert.False(t, tk.ValidateOrigin("http://sequence.xyz"))
 		assert.True(t, tk.ValidateOrigin("http://docs.sequence.xyz"))
 		assert.True(t, tk.ValidateOrigin("http://test.sequence.xyz"))
+		assert.True(t, tk.ValidateOrigin("http://dev.test.sequence.xyz"))
 	})
 }
 


### PR DESCRIPTION
Issue: https://github.com/0xsequence/issue-tracker/issues/263

Match these patterns
```
* allow everything (same as empty list)
sequence.app - exact origin match
*.sequence.app - match any subdomain
https://*.sequence.app - match any subdomain and require https
```