### PR TITLE
Pass cycle to getLimit

### DIFF
--- a/mem.go
+++ b/mem.go
@@ -36,7 +36,7 @@ func (m *MemoryStore) SetAccessLimit(ctx context.Context, projectID uint64, conf
 	return nil
 }
 
-func (m *MemoryStore) GetAccessLimit(ctx context.Context, projectID uint64) (*proto.Limit, error) {
+func (m *MemoryStore) GetAccessLimit(ctx context.Context, projectID uint64, cycle *proto.Cycle) (*proto.Limit, error) {
 	m.Lock()
 	limit, ok := m.limits[projectID]
 	m.Unlock()

--- a/middleware/access.go
+++ b/middleware/access.go
@@ -63,7 +63,7 @@ func VerifyAccessKey(client Client, eh ErrorHandler) func(next http.Handler) htt
 				return
 			}
 
-			quota, err := client.FetchKeyQuota(ctx, accessKey, r.Header.Get(HeaderOrigin), getTime(ctx))
+			quota, err := client.FetchKeyQuota(ctx, accessKey, r.Header.Get(HeaderOrigin), GetTime(ctx))
 			if err != nil {
 				eh(w, r, next, err)
 				return
@@ -97,7 +97,7 @@ func EnsureUsage(client Client, eh ErrorHandler) func(next http.Handler) http.Ha
 				return
 			}
 
-			usage, err := client.FetchUsage(ctx, quota, getTime(ctx))
+			usage, err := client.FetchUsage(ctx, quota, GetTime(ctx))
 			if err != nil {
 				eh(w, r, next, err)
 				return
@@ -163,7 +163,7 @@ func SpendUsage(client Client, eh ErrorHandler) func(next http.Handler) http.Han
 				return
 			}
 
-			ok, err := client.SpendQuota(ctx, quota, cu, getTime(ctx))
+			ok, err := client.SpendQuota(ctx, quota, cu, GetTime(ctx))
 			if err != nil {
 				eh(w, r, next, err)
 				return

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -111,8 +111,8 @@ func WithTime(ctx context.Context, now time.Time) context.Context {
 	return context.WithValue(ctx, ctxKeyTime, now)
 }
 
-// getTime returns the time from the context. If the time is not set, it returns the current time.
-func getTime(ctx context.Context) time.Time {
+// GetTime returns the time from the context. If the time is not set, it returns the current time.
+func GetTime(ctx context.Context) time.Time {
 	v, ok := ctx.Value(ctxKeyTime).(time.Time)
 	if !ok {
 		return time.Now().Truncate(time.Hour * 24)


### PR DESCRIPTION
The `GetAccessLimit` method now requires the billing cycle (start-end), in case the limit depends on other factors.