### PR TITLE
early exit if session has been already set

### DIFF
--- a/client.go
+++ b/client.go
@@ -197,7 +197,7 @@ func (c *Client) FetchUsage(ctx context.Context, quota *proto.AccessQuota, now t
 }
 
 func (c *Client) CheckPermission(ctx context.Context, projectID uint64, minPermission proto.UserPermission) (bool, error) {
-	if sessionType := middleware.GetSessionType(ctx); sessionType >= proto.SessionType_Admin {
+	if sessionType, _ := middleware.GetSessionType(ctx); sessionType >= proto.SessionType_Admin {
 		return true, nil
 	}
 	perm, _, err := c.FetchPermission(ctx, projectID)

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -35,12 +35,12 @@ func WithSessionType(ctx context.Context, accessType proto.SessionType) context.
 }
 
 // GetSessionType returns the access key from the context.
-func GetSessionType(ctx context.Context) proto.SessionType {
+func GetSessionType(ctx context.Context) (proto.SessionType, bool) {
 	v, ok := ctx.Value(ctxKeySessionType).(proto.SessionType)
 	if !ok {
-		return proto.SessionType_Public
+		return proto.SessionType_Public, false
 	}
-	return v
+	return v, true
 }
 
 // WithAccount adds the account to the context.

--- a/middleware/middleware_access.go
+++ b/middleware/middleware_access.go
@@ -30,7 +30,7 @@ func AccessControl(acl ServiceConfig[ACL], cost ServiceConfig[int64], defaultCos
 				return
 			}
 
-			if session := GetSessionType(r.Context()); !types.Includes(session) {
+			if session, _ := GetSessionType(r.Context()); !types.Includes(session) {
 				eh(r, w, proto.ErrUnauthorized)
 				return
 			}

--- a/middleware/middleware_ratelimit.go
+++ b/middleware/middleware_ratelimit.go
@@ -78,14 +78,14 @@ func RateLimit(rlCfg RLConfig, redisCfg redis.Config, eh ErrHandler) func(next h
 		httprate.WithLimitCounter(limitCounter),
 		httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
 			ctx := r.Context()
+			if _, ok := GetService(ctx); ok {
+				return "", nil
+			}
 			if q, ok := GetAccessQuota(ctx); ok {
 				return ProjectRateKey(q.GetProjectID()), nil
 			}
 			if account, ok := GetAccount(ctx); ok {
 				return AccountRateKey(account), nil
-			}
-			if _, ok := GetService(ctx); ok {
-				return "", nil
 			}
 			return httprate.KeyByRealIP(r)
 		}),

--- a/middleware/middleware_session.go
+++ b/middleware/middleware_session.go
@@ -34,6 +34,10 @@ func Session(client Client, auth *jwtauth.JWTAuth, u UserStore, eh ErrHandler, k
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+			if _, ok := GetSessionType(ctx); ok {
+				next.ServeHTTP(w, r)
+				return
+			}
 			var (
 				sessionType proto.SessionType
 				quota       *proto.AccessQuota


### PR DESCRIPTION
We need early exit in the session if a custom middleware already set the session.