### PR TITLE
fix: handle additional error case in GetAccessQuota method

### DIFF
--- a/server.go
+++ b/server.go
@@ -237,8 +237,8 @@ func (s server) GetProjectQuota(ctx context.Context, projectID uint64, now time.
 func (s server) GetAccessQuota(ctx context.Context, accessKey string, now time.Time) (*proto.AccessQuota, error) {
 	access, err := s.store.AccessKeyStore.FindAccessKey(ctx, accessKey)
 	if err != nil {
-		if errors.Is(err, proto.ErrAccessKeyNotFound) {
-			return nil, proto.ErrAccessKeyNotFound
+		if errors.Is(err, proto.ErrAccessKeyNotFound) || errors.Is(err, proto.ErrProjectNotFound) {
+			return nil, err
 		}
 		return nil, fmt.Errorf("find access key: %w", err)
 	}


### PR DESCRIPTION
WebRPC can't detect a `WebRPCError` if it's wrapped.

This call:
```bash
curl --location 'https://quotacontrolserver/rpc/QuotaControl/GetAccessQuota' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer XXX' \
--data '{
    "accessKey": "abc"
}'
```
Returns:
```json
{
    "error": "WebrpcEndpoint",
    "code": 0,
    "msg": "endpoint error",
    "cause": "find access key: ProjectNotFound 1008: Project not found",
    "status": 400
}
```

This PR fixes it by handling the error