### PR TITLE
Downgrade to ethkit v1.30.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 )
 
 require (
-	github.com/0xsequence/ethkit v1.38.0 // indirect
+	github.com/0xsequence/ethkit v1.30.3 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/0xsequence/authcontrol v0.4.8 h1:SsJYwWLPLDXRSxsJvUY6bTO73FvgiOA2S1olx9D0Lpk=
 github.com/0xsequence/authcontrol v0.4.8/go.mod h1:Yec+rjPmbmXtGJoZCk6I9Liq50blsbnlFEJgbagrEt0=
-github.com/0xsequence/ethkit v1.38.0 h1:6tTGyPycJuPboOY4G6z6a/JoGArPfgfVyIe+pTeeZiQ=
-github.com/0xsequence/ethkit v1.38.0/go.mod h1:8OJ6MUtw3gCiUHIsp4yhRsCnwHj9whkWMX23408FhRg=
+github.com/0xsequence/ethkit v1.30.3 h1:NnvDeJunjPwdzc2axjqeWgpjNWbEBx2AtIbrC5xNEps=
+github.com/0xsequence/ethkit v1.30.3/go.mod h1:rv0FAIyEyN0hhwGefbduAz4ujmyjyJXhCd6a0/yF3tk=
 github.com/0xsequence/go-sequence v0.44.2 h1:UMc0DWme4bcFl32OZu2ace4wNh5XkUI9AQ2cUGtn3/g=
 github.com/0xsequence/go-sequence v0.44.2/go.mod h1:taksc+Fh5cMK07swbzJa4BKNKmfi9qbNEiIWoElW2GU=
 github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 h1:uvdUDbHQHO85qeSydJtItA4T55Pw6BtAejd0APRJOCE=

--- a/go.work.sum
+++ b/go.work.sum
@@ -156,6 +156,8 @@ github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzh
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
+github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=
+github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
@@ -182,7 +184,6 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c h1:aqg5Vm5dwtvL+YgDpBcK1ITf3o96N/K7/wsRXQnUTEs=
 github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c/go.mod h1:owqhoLW1qZoYLZzLnBw+QkPP9WZnjlSWihhxAJC1+/M=


### PR DESCRIPTION
`go mod why` doesn't help.. 

but it turns out that `go work vendor` diff shows that all these transitive dependencies were caused by `prototyp.Hash` / `prototyp.BigInt` types. 

... in quotacontrol??

I think we'll need to split them into their own packages too.


```
vendor/github.com/0xsequence/go-sequence/lib/prototyp/hash.go:8:    "github.com/0xsequence/ethkit/go-ethereum/common"
```