### PR TITLE
feat(quota-v2): cache middleware

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -19,6 +19,10 @@ type Cache struct {
 	Projects    cache.Simple[KeyProject, *proto.AccessQuota]
 	Permissions cache.Simple[KeyPermission, UserPermission]
 	Usage       cache.Usage[KeyUsage]
+
+	ProjectInfo cache.Simple[KeyProjectInfo, *proto.ProjectInfo]
+	Limits      cache.Simple[KeyLimit, *proto.Limit]
+	Keys        cache.Simple[KeyAccessKeyV2, *proto.AccessKey]
 }
 
 // NewCache creates a Cache backed by Redis using the new generic cache package.
@@ -29,11 +33,17 @@ func NewCache(client *redis.Client, ttl time.Duration, lruSize int, lruExpiratio
 		Projects:    cache.RedisCache[KeyProject, *proto.AccessQuota]{Backend: backend},
 		Permissions: cache.RedisCache[KeyPermission, UserPermission]{Backend: backend},
 		Usage:       cache.NewUsageCache[KeyUsage](backend),
+		ProjectInfo: cache.RedisCache[KeyProjectInfo, *proto.ProjectInfo]{Backend: backend},
+		Limits:      cache.RedisCache[KeyLimit, *proto.Limit]{Backend: backend},
+		Keys:        cache.RedisCache[KeyAccessKeyV2, *proto.AccessKey]{Backend: backend},
 	}
 	if lruSize > 0 {
 		c.AccessKeys = cache.NewMemory(c.AccessKeys, lruSize, lruExpiration)
 		c.Projects = cache.NewMemory(c.Projects, lruSize, lruExpiration)
 		c.Permissions = cache.NewMemory(c.Permissions, lruSize, lruExpiration)
+		c.ProjectInfo = cache.NewMemory(c.ProjectInfo, lruSize, lruExpiration)
+		c.Limits = cache.NewMemory(c.Limits, lruSize, lruExpiration)
+		c.Keys = cache.NewMemory(c.Keys, lruSize, lruExpiration)
 	}
 	return c
 }

--- a/client.go
+++ b/client.go
@@ -175,6 +175,62 @@ func (c *Client) FetchUsage(ctx context.Context, projectID uint64, cycle *proto.
 	return c.cache.Usage.Ensure(ctx, c.getFetcher(), newKeyUsage(projectID, c.service, cycle, now))
 }
 
+func (c *Client) FetchProjectInfo(ctx context.Context, projectID uint64) (*proto.ProjectInfo, error) {
+	info, ok, err := c.cache.ProjectInfo.Get(ctx, KeyProjectInfo{ProjectID: projectID})
+	if err != nil {
+		c.logger.Warn("project info cache error", xlog.Error(err))
+	}
+	if ok {
+		return info, nil
+	}
+	info, err = c.quotaClient.GetProjectInfo(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.cache.ProjectInfo.Set(ctx, KeyProjectInfo{ProjectID: projectID}, info); err != nil {
+		c.logger.Warn("failed to cache project info", xlog.Error(err))
+	}
+	return info, nil
+}
+
+func (c *Client) FetchServiceLimit(ctx context.Context, projectID uint64) (*proto.Limit, error) {
+	key := KeyLimit{ProjectID: projectID, Service: c.service}
+	limit, ok, err := c.cache.Limits.Get(ctx, key)
+	if err != nil {
+		c.logger.Warn("limit cache error", xlog.Error(err))
+	}
+	if ok {
+		return limit, nil
+	}
+	limit, err = c.quotaClient.GetServiceLimit(ctx, projectID, c.service)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.cache.Limits.Set(ctx, key, limit); err != nil {
+		c.logger.Warn("failed to cache service limit", xlog.Error(err))
+	}
+	return limit, nil
+}
+
+func (c *Client) FetchAccessKey(ctx context.Context, accessKey string) (*proto.AccessKey, error) {
+	key := KeyAccessKeyV2{AccessKey: accessKey}
+	ak, ok, err := c.cache.Keys.Get(ctx, key)
+	if err != nil {
+		c.logger.Warn("access key cache error", xlog.Error(err))
+	}
+	if ok {
+		return ak, nil
+	}
+	ak, err = c.quotaClient.GetAccessKey(ctx, accessKey)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.cache.Keys.Set(ctx, key, ak); err != nil {
+		c.logger.Warn("failed to cache access key", xlog.Error(err))
+	}
+	return ak, nil
+}
+
 func (c *Client) CheckPermission(ctx context.Context, projectID uint64, minPermission proto.UserPermission) (bool, error) {
 	if sessionType, _ := authcontrol.GetSessionType(ctx); sessionType >= authproto.SessionType_Admin {
 		return true, nil

--- a/client.go
+++ b/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/0xsequence/go-libs/xlog"
 	"github.com/redis/go-redis/v9"
 
-	"github.com/0xsequence/quotacontrol/cache"
 	"github.com/0xsequence/quotacontrol/internal/usage"
 	"github.com/0xsequence/quotacontrol/middleware"
 	"github.com/0xsequence/quotacontrol/proto"
@@ -65,12 +64,7 @@ type Client struct {
 
 	service proto.Service
 	usage   *usage.Tracker
-	cache   struct {
-		AccessKeys  cache.Simple[KeyAccessKey, *proto.AccessQuota]
-		Projects    cache.Simple[KeyProject, *proto.AccessQuota]
-		Permissions cache.Simple[KeyPermission, UserPermission]
-		Usage       cache.Usage[KeyUsage]
-	}
+	cache Cache
 	quotaClient proto.QuotaControlClient
 
 	running int32

--- a/keys.go
+++ b/keys.go
@@ -62,6 +62,27 @@ func (k KeyPermission) String() string {
 	return fmt.Sprintf("perm:%s:%d:%s", Version, k.ProjectID, k.UserID)
 }
 
+type KeyProjectInfo struct{ ProjectID uint64 }
+
+func (k KeyProjectInfo) String() string {
+	return fmt.Sprintf("info:%s:%d", Version, k.ProjectID)
+}
+
+type KeyLimit struct {
+	ProjectID uint64
+	Service   proto.Service
+}
+
+func (k KeyLimit) String() string {
+	return fmt.Sprintf("limit:%s:%d:%s", Version, k.ProjectID, k.Service.String())
+}
+
+type KeyAccessKeyV2 struct{ AccessKey string }
+
+func (k KeyAccessKeyV2) String() string {
+	return fmt.Sprintf("ak:%s:%s", Version, k.AccessKey)
+}
+
 type UserPermission struct {
 	UserPermission proto.UserPermission  `json:"userPerm"`
 	ResourceAccess *proto.ResourceAccess `json:"resourceAccess"`

--- a/middleware/common.go
+++ b/middleware/common.go
@@ -75,6 +75,9 @@ type Client interface {
 	FetchUsage(ctx context.Context, projectID uint64, cycle *proto.Cycle, now time.Time) (int64, error)
 	CheckPermission(ctx context.Context, projectID uint64, minPermission proto.UserPermission) (bool, error)
 	SpendUsage(ctx context.Context, quota *proto.AccessQuota, cost int64, now time.Time) (bool, int64, error)
+	FetchProjectInfo(ctx context.Context, projectID uint64) (*proto.ProjectInfo, error)
+	FetchServiceLimit(ctx context.Context, projectID uint64) (*proto.Limit, error)
+	FetchAccessKey(ctx context.Context, accessKey string) (*proto.AccessKey, error)
 }
 
 func VerifyChains(ctx context.Context, chainIDs ...uint64) error {

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -19,10 +19,11 @@ func (k *contextKey) String() string {
 }
 
 var (
-	ctxKeyAccessQuota = &contextKey{"AccessQuota"}
-	ctxKeyCost        = &contextKey{"Cost"}
-	ctxKeyTime        = &contextKey{"Time"}
-	ctxKeySpending    = &contextKey{"Spending"}
+	ctxKeyAccessQuota  = &contextKey{"AccessQuota"}
+	ctxKeyServiceLimit = &contextKey{"ServiceLimit"}
+	ctxKeyCost         = &contextKey{"Cost"}
+	ctxKeyTime         = &contextKey{"Time"}
+	ctxKeySpending     = &contextKey{"Spending"}
 )
 
 // withAccessQuota adds the quota to the context.
@@ -33,6 +34,16 @@ func withAccessQuota(ctx context.Context, quota *proto.AccessQuota) context.Cont
 // GetAccessQuota returns the access quota from the context.
 func GetAccessQuota(ctx context.Context) (*proto.AccessQuota, bool) {
 	v, ok := ctx.Value(ctxKeyAccessQuota).(*proto.AccessQuota)
+	return v, ok
+}
+
+func withServiceLimit(ctx context.Context, limit *proto.Limit) context.Context {
+	return context.WithValue(ctx, ctxKeyServiceLimit, limit)
+}
+
+// GetServiceLimit returns the per-service limit from the context.
+func GetServiceLimit(ctx context.Context) (*proto.Limit, bool) {
+	v, ok := ctx.Value(ctxKeyServiceLimit).(*proto.Limit)
 	return v, ok
 }
 

--- a/middleware/middleware_quota.go
+++ b/middleware/middleware_quota.go
@@ -118,6 +118,7 @@ func VerifyQuota(client Client, o Options) func(next http.Handler) http.Handler 
 				}
 
 				ctx = withAccessQuota(ctx, quota)
+				ctx = withServiceLimit(ctx, &cfg)
 				w.Header().Set(HeaderQuotaLimit, strconv.FormatInt(cfg.FreeMax, 10))
 			}
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/middleware/middleware_usage.go
+++ b/middleware/middleware_usage.go
@@ -50,9 +50,9 @@ func EnsureUsage(client Client, o Options) func(next http.Handler) http.Handler 
 				return
 			}
 
-			limit, ok := quota.Limit.GetSettings(client.GetService())
+			limit, ok := GetServiceLimit(ctx)
 			if !ok {
-				o.ErrHandler(r, w, proto.ErrAborted.WithCausef("verify quota: service limit not found for %s", client.GetService().GetName()))
+				o.ErrHandler(r, w, proto.ErrAborted.WithCausef("verify quota: service limit not found"))
 				return
 			}
 
@@ -99,9 +99,9 @@ func SpendUsage(client Client, o Options) func(next http.Handler) http.Handler {
 			}
 			w.Header().Set(HeaderQuotaCost, strconv.FormatInt(cu, 10))
 
-			limit, ok := quota.Limit.GetSettings(client.GetService())
+			limit, ok := GetServiceLimit(ctx)
 			if !ok {
-				o.ErrHandler(r, w, proto.ErrAborted.WithCausef("verify quota: service limit not found for %s", client.GetService().GetName()))
+				o.ErrHandler(r, w, proto.ErrAborted.WithCausef("verify quota: service limit not found"))
 				return
 			}
 

--- a/server.go
+++ b/server.go
@@ -528,6 +528,9 @@ func (s server) ClearServiceLimitCache(ctx context.Context, projectID uint64, se
 }
 
 func (s server) ClearAccessKeyCache(ctx context.Context, accessKey string) (bool, error) {
+	if _, err := s.cache.AccessKeys.Clear(ctx, KeyAccessKey{AccessKey: accessKey}); err != nil {
+		return false, fmt.Errorf("clear access key cache: %w", err)
+	}
 	if _, err := s.cache.Keys.Clear(ctx, KeyAccessKeyV2{AccessKey: accessKey}); err != nil {
 		return false, fmt.Errorf("clear access key cache: %w", err)
 	}

--- a/server.go
+++ b/server.go
@@ -510,6 +510,9 @@ func (s server) GetProjectInfo(ctx context.Context, projectID uint64) (*proto.Pr
 }
 
 func (s server) ClearProjectInfoCache(ctx context.Context, projectID uint64) (bool, error) {
+	if _, err := s.cache.ProjectInfo.Clear(ctx, KeyProjectInfo{ProjectID: projectID}); err != nil {
+		return false, fmt.Errorf("clear project info cache: %w", err)
+	}
 	return true, nil
 }
 
@@ -518,10 +521,16 @@ func (s server) GetServiceLimit(ctx context.Context, projectID uint64, service p
 }
 
 func (s server) ClearServiceLimitCache(ctx context.Context, projectID uint64, service proto.Service) (bool, error) {
+	if _, err := s.cache.Limits.Clear(ctx, KeyLimit{ProjectID: projectID, Service: service}); err != nil {
+		return false, fmt.Errorf("clear service limit cache: %w", err)
+	}
 	return true, nil
 }
 
 func (s server) ClearAccessKeyCache(ctx context.Context, accessKey string) (bool, error) {
+	if _, err := s.cache.Keys.Clear(ctx, KeyAccessKeyV2{AccessKey: accessKey}); err != nil {
+		return false, fmt.Errorf("clear access key cache: %w", err)
+	}
 	return true, nil
 }
 
@@ -533,6 +542,9 @@ func (s server) updateAccessKey(ctx context.Context, k *proto.AccessKey) (*proto
 
 	if _, err := s.cache.AccessKeys.Clear(ctx, KeyAccessKey{AccessKey: k.AccessKey}); err != nil {
 		s.log.Error("delete access quota from cache", xlog.Error(err))
+	}
+	if _, err := s.cache.Keys.Clear(ctx, KeyAccessKeyV2{AccessKey: k.AccessKey}); err != nil {
+		s.log.Error("delete access key from cache", xlog.Error(err))
 	}
 
 	return k, nil

--- a/server_test.go
+++ b/server_test.go
@@ -1042,6 +1042,142 @@ func TestPerServiceRateLimit(t *testing.T) {
 
 }
 
+func TestV2Endpoints(t *testing.T) {
+	cfg := newConfig()
+	server, cleanup := mock.NewServer(&cfg)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	key := authcontrol.GenerateAccessKey(authcontrol.WithVersion(ctx, 1), ProjectID)
+
+	svcLimit := proto.Limit{RateLimit: 100, FreeWarn: 500, FreeMax: 500, OverWarn: 700, OverMax: 1000}
+	require.NoError(t, server.Store.SetLimit(ctx, ProjectID, Service, svcLimit))
+	require.NoError(t, server.Store.InsertAccessKey(ctx, &proto.AccessKey{Active: true, AccessKey: key, ProjectID: ProjectID}))
+
+	logger := slog.Default()
+	client := quotacontrol.NewClient(logger, Service, cfg, nil)
+
+	now := time.Now()
+
+	t.Run("FetchProjectInfo", func(t *testing.T) {
+		info, err := client.FetchProjectInfo(ctx, ProjectID)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, ProjectID, info.ID)
+
+		// second call should hit cache
+		info2, err := client.FetchProjectInfo(ctx, ProjectID)
+		require.NoError(t, err)
+		assert.Equal(t, info.ID, info2.ID)
+	})
+
+	t.Run("FetchServiceLimit", func(t *testing.T) {
+		limit, err := client.FetchServiceLimit(ctx, ProjectID)
+		require.NoError(t, err)
+		require.NotNil(t, limit)
+		assert.Equal(t, svcLimit.FreeMax, limit.FreeMax)
+		assert.Equal(t, svcLimit.OverMax, limit.OverMax)
+		assert.Equal(t, svcLimit.RateLimit, limit.RateLimit)
+
+		// second call should hit cache
+		limit2, err := client.FetchServiceLimit(ctx, ProjectID)
+		require.NoError(t, err)
+		assert.Equal(t, limit.FreeMax, limit2.FreeMax)
+	})
+
+	t.Run("FetchAccessKey", func(t *testing.T) {
+		ak, err := client.FetchAccessKey(ctx, key)
+		require.NoError(t, err)
+		require.NotNil(t, ak)
+		assert.Equal(t, key, ak.AccessKey)
+		assert.Equal(t, ProjectID, ak.ProjectID)
+		assert.True(t, ak.Active)
+
+		// second call should hit cache
+		ak2, err := client.FetchAccessKey(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, ak.AccessKey, ak2.AccessKey)
+	})
+
+	t.Run("V2MatchesLegacy", func(t *testing.T) {
+		server.FlushCache(ctx)
+
+		// legacy path
+		quota, err := client.FetchKeyQuota(ctx, key, "", nil, now)
+		require.NoError(t, err)
+		require.NotNil(t, quota)
+
+		server.FlushCache(ctx)
+
+		// v2 paths
+		info, err := client.FetchProjectInfo(ctx, ProjectID)
+		require.NoError(t, err)
+		assert.Equal(t, quota.Info.ID, info.ID)
+
+		limit, err := client.FetchServiceLimit(ctx, ProjectID)
+		require.NoError(t, err)
+		legacyCfg, ok := quota.Limit.GetSettings(Service)
+		require.True(t, ok)
+		assert.Equal(t, legacyCfg.FreeMax, limit.FreeMax)
+		assert.Equal(t, legacyCfg.OverMax, limit.OverMax)
+		assert.Equal(t, legacyCfg.RateLimit, limit.RateLimit)
+
+		ak, err := client.FetchAccessKey(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, quota.AccessKey.AccessKey, ak.AccessKey)
+		assert.Equal(t, quota.AccessKey.ProjectID, ak.ProjectID)
+	})
+
+	t.Run("CacheInvalidation", func(t *testing.T) {
+		server.FlushCache(ctx)
+
+		// populate v2 caches
+		_, err := client.FetchProjectInfo(ctx, ProjectID)
+		require.NoError(t, err)
+		_, err = client.FetchServiceLimit(ctx, ProjectID)
+		require.NoError(t, err)
+
+		// update the limit in the store
+		newLimit := proto.Limit{RateLimit: 200, FreeWarn: 1000, FreeMax: 1000, OverWarn: 1400, OverMax: 2000}
+		require.NoError(t, server.Store.SetLimit(ctx, ProjectID, Service, newLimit))
+
+		// cached value should still be old
+		limit, err := client.FetchServiceLimit(ctx, ProjectID)
+		require.NoError(t, err)
+		assert.Equal(t, svcLimit.FreeMax, limit.FreeMax)
+
+		// flush redis cache, forcing re-fetch from server
+		server.FlushCache(ctx)
+
+		// now should get fresh data
+		limit, err = client.FetchServiceLimit(ctx, ProjectID)
+		require.NoError(t, err)
+		assert.Equal(t, newLimit.FreeMax, limit.FreeMax)
+
+		// restore original limit
+		require.NoError(t, server.Store.SetLimit(ctx, ProjectID, Service, svcLimit))
+	})
+
+	t.Run("ClearLegacyCache", func(t *testing.T) {
+		server.FlushCache(ctx)
+
+		// populate legacy cache
+		_, err := client.FetchKeyQuota(ctx, key, "", nil, now)
+		require.NoError(t, err)
+
+		// clear legacy project cache
+		require.NoError(t, client.ClearQuotaCacheByProjectID(ctx, ProjectID))
+
+		// clear legacy access key cache
+		require.NoError(t, client.ClearQuotaCacheByAccessKey(ctx, key))
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := client.FetchAccessKey(ctx, "nonexistent")
+		assert.ErrorIs(t, err, proto.ErrAccessKeyNotFound)
+	})
+}
+
 func newConfig() quotacontrol.Config {
 	return quotacontrol.Config{
 		Enabled:    true,


### PR DESCRIPTION
## Quota V2: Decompose monolithic AccessQuota cache

`AccessQuota` bundles project info, legacy limits, and access key data into a single cached blob. This means any change to limits invalidates the entire quota cache, and services that only need project info still pay for deserializing everything.

This stack decomposes `AccessQuota` into independently cached pieces — `ProjectInfo`, per-service `Limit`, and `AccessKey` — each with its own RPC endpoint and cache key. This lets consumers fetch only what they need and invalidate caches granularly.

### This PR (3/3): Cache + client + middleware

- Adds individual Redis caches for `ProjectInfo`, `Limit`, and `AccessKey` with versioned cache keys
- Extracts inline cache struct into named `Cache` type, adds V2 fields
- Adds client fetch methods: `FetchProjectInfo`, `FetchServiceLimit`, `FetchAccessKey`
- Middleware now reads per-service `Limit` from context (set by `VerifyQuota`) instead of extracting from the legacy `LegacyLimit` map — `EnsureUsage` and `SpendUsage` use `GetServiceLimit(ctx)` directly

Part of stack: **quota-v2**

Base: `quota-v2/server-plumbing`

<!-- sdf:stack-nav -->
---
Stack: `quota-v2`
1. https://github.com/0xsequence/quotacontrol/pull/144
2. https://github.com/0xsequence/quotacontrol/pull/145
3. https://github.com/0xsequence/quotacontrol/pull/146 ◀ this PR
4. https://github.com/0xsequence/quotacontrol/pull/147

<sub>This stack is managed with [sdf](https://stacked-diffs-flow.com).</sub>
<!-- /sdf:stack-nav -->